### PR TITLE
- extended CreationParameters class for the attributes CHUNKSIZE_SP and

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,15 @@ If a coverage is used please make sure that the coordinates of the images refer 
 ### Deleting arrays
 In order to allow GDAL to delete arrays, we enabled this particular feature via gdalmanage. Since gdalmanage does not support opening options, the connection string approach must be used, e.g. `gdalmanage delete "SCIDB:array=test_spatial host=https://your.host.de port=31000 user=user password=passwd confirmDelete=Y"`. This command completely removes the array from the database. Please be sure that the array is gone once this command is executed. An additional parameter "confirmDelete" was introduced in order to prevent accidental deletion of an array. This is due to GDALs QuietDelete function that is called on each gdal_translate call. As values the following strings are allowed (case-insensitive): YES, Y, TRUE, T or 1.
 
+### Adjusting chunksizes manually
+SciDB manages its data in so called chunks. Pradigm4 suggests for those chunks to select sizes so that each chunk uses about 10 to 20 MB storage. Important to know is also that the chunks are stored for each attribute individually that are combined by a process called vertical partioning [link] (http://paradigm4.com/HTMLmanual/13.3/scidb_ug/ch04s05s02.htmlhttp://paradigm4.com/HTMLmanual/13.3/scidb_ug/ch04s05s02.html). In order to chose a suitable size this plugin will calculate chunksizes based on the spatial dimensions, the temporal dimension (if set) and the attributes data type sizes. Also we allow the setting of custom chunksizes with the create option keys "CHUNKSIZE_SP" and "CHUNKSIZE_T". The values that are required in this key-value pairs are the number of cells (integer value). If just one chunksize is stated the missing one will be calculated using the default total chunk size of 32MB and the biggest data type of the bands. In the case you don't specify a chunksize the default temporal chunksize of 1 is assumed and the spatial chunksize will be treated as missing and therefore calculated.
 
-### NA (no-data) value handling
-The SciDB driver evaluates and handles assigned no data values and stores them as metadata in SciDB. To get the benefits of this feature, make sure that the NA value are assigned in the source dataset (e.g. by using `gdal_translate -a_nodata=0 ...`). The assgined no-data value will also be used to prevent SciDB to overwrite already existing cells in the array with no data values. SciDB will evaluate the cells in a way that if at least one band shows a no-data value, then those cells are neglected from insertion. Otherwise SciDB will always overwrite existing cells with the values of an array added afterwards in case there is an overlap. At the moment there is no way to prevent this behavior. Please make sure to add images or tiles to an array in a specific order to get the best coverage results.
-
-
+Examples:
+```
+gdal_translate (...) -co "CHUNKSIZE_SP=3000" -co "CHUNKSIZE_T=1" -of SciDB input.tif "SCIDB:array=targetArray"
+gdal_translate (...) -co "CHUNKSIZE_SP=6000" -of SciDB input.tif "SCIDB:array=targetArray"
+gdal_translate (...) -co -co "CHUNKSIZE_T=10" -of SciDB input.tif "SCIDB:array=targetArray"
+```
 ## Dependencies
 - At the moment the driver requires [Shim](https://github.com/Paradigm4/shim) to run on SciDB databases you want to connect to. In the future, this may or may not be changed to connecting directly to SciDB sockets using Google's protocol buffers
 - [ST plugin] (https://github.com/mappl/scidb4geo) for SciDB

--- a/src/parameter_parser.cpp
+++ b/src/parameter_parser.cpp
@@ -29,7 +29,9 @@ namespace scidb4gdal
     {
       //set the resolver a.k.a the key value pairs in the connection / property string or the create / opening options
       _creationTypeResolver.mapping = map_list_of("S",S_ARRAY) ("ST",ST_ARRAY) ("STS",ST_SERIES);
-      _propKeyResolver.mapping = map_list_of ("dt",TRS) ("timestamp",TIMESTAMP) ("t",TIMESTAMP) ("type",TYPE)("i", T_INDEX) ("bbox",BBOX) ("srs",SRS);
+      
+      _propKeyResolver.mapping = map_list_of ("dt",TRS) ("timestamp",TIMESTAMP) ("t",TIMESTAMP) ("type",TYPE)("i", T_INDEX) ("bbox",BBOX) ("srs",SRS) ("CHUNKSIZE_SP",CHUNKSIZE_SPATIAL)("chunksize_sp",CHUNKSIZE_SPATIAL)("CHUNKSIZE_T",CHUNKSIZE_TEMPORAL)("chunksize_t",CHUNKSIZE_TEMPORAL);
+      
       _conKeyResolver.mapping = map_list_of ("host", HOST)("port", PORT) ("user",USER) ("password", PASSWORD) ("ssl",SSL)("array",ARRAY)("confirmDelete",CONFIRM_DELETE);
       
       _scidb_filename = scidbFile;
@@ -381,6 +383,22 @@ namespace scidb4gdal
 	    _create->hasBBOX = true;
 	    break;    
 	  }
+	  case CHUNKSIZE_SPATIAL:
+	    try {
+	      _create->chunksize_spatial = boost::lexical_cast<int>(value);
+	    } catch (boost::bad_lexical_cast e) {
+		Utils::debug(e.what());
+		throw ERR_GLOBAL_PARSE;
+	    }
+	    break;
+	  case CHUNKSIZE_TEMPORAL:
+	    try {
+	      _create->chunksize_temporal = boost::lexical_cast<int>(value);
+	    } catch (boost::bad_lexical_cast e) {
+	      Utils::debug(e.what());
+	      throw ERR_GLOBAL_PARSE;
+	    }
+	    break;
 	}
     }
     void ParameterParser::assignQueryParameter(string key, string value)

--- a/src/scidbdriver.h
+++ b/src/scidbdriver.h
@@ -206,9 +206,10 @@ namespace scidb4gdal
        * 
        * @param poSrcDS a pointer to a GDALDataset
        * @param array a SciDBSpatialArray that will be modified (output)
+       * @param options The scidb4gdal::CreationParameters
        * @return void
        */
-      static void copyMetadataToArray(GDALDataset* poSrcDS, SciDBSpatialArray &array);
+      static void copyMetadataToArray(GDALDataset* poSrcDS, SciDBSpatialArray &array,CreationParameters* options);
       
       /**
        * @brief Transmits and stores an image into a temporal SciDB array

--- a/src/shim_client_structs.h
+++ b/src/shim_client_structs.h
@@ -44,7 +44,7 @@ namespace scidb4gdal {
    * Enum for a switch-case statement when parsing the properties part of a connection string
    */
   enum Properties {
-    T_INDEX, TRS, TIMESTAMP, TYPE, BBOX, SRS
+    T_INDEX, TRS, TIMESTAMP, TYPE, BBOX, SRS,CHUNKSIZE_SPATIAL, CHUNKSIZE_TEMPORAL
   };
   
   /** 
@@ -92,6 +92,10 @@ namespace scidb4gdal {
     bool hasBBOX;
     /** error code if validation fails */
     StatusCode error;
+    /** the chunksize for each of the spatial dimensions*/
+    int chunksize_spatial = -1;
+    /** the blocksize for the temporal dimension */
+    int chunksize_temporal = -1;
     
     /**
      * @brief validates the parameters for completenes

--- a/test/dev_test.sh
+++ b/test/dev_test.sh
@@ -50,6 +50,7 @@ targetArrayMetaNA=test_chicago_s_meta_na
 targetArraySCov=test_chicago_s_cov
 targetArraySTSCov=test_chicago_sts_cov
 targetArrayConEnv=test_chicago_con_env
+target_var_chunk=test_chicago_chunk
 
 #output file names
 rm -f ./test_*.tif
@@ -178,6 +179,9 @@ time {
   echo gdalmanage delete \"SCIDB:array=${targetArraySTSCov} host=${host} port=${port} user=${user} password=${passwd} confirmDelete=y\"
   gdalmanage delete "SCIDB:array=${targetArraySTSCov} host=${host} port=${port} user=${user} password=${passwd} confirmDelete=y"
   echo ""
+  echo gdalmanage delete \"SCIDB:array=${targetArrayNACov} confirmDelete=y\"
+  gdalmanage delete "SCIDB:array=${target_var_chunk} confirmDelete=y"
+  echo ""
 }
 echo "" 
 echo "###########################################"
@@ -211,6 +215,14 @@ time {
   echo gdal_translate --debug ON -co \"type=S\" -of SciDB ${chicago} \"SCIDB:array=${targetArrayConEnv}\"
   gdal_translate --debug ON -co "type=S" -of SciDB "${chicago}" "SCIDB:array=${targetArrayConEnv}"
   check $?
+}
+echo ""
+
+TIMEFORMAT='Upload of chicago image with adaptible chunksizes took %R seconds to complete'
+time {
+  echo "****** uploading image with adaptible chunksizes"
+  echo gdal_translate --debug ON -co \"type=ST\" -co \"t=2015-02-25\" -co \"dt=P1D\" -co \"CHUNKSIZE_SP=3000\" -of SciDB ${chicago_na} \"SCIDB:array=${target_var_chunk}\"
+  gdal_translate --debug ON -co "type=ST" -co "t=2015-02-25" -co "dt=P1D" -co "CHUNKSIZE_SP=3000" -of SciDB "${chicago_na}" "SCIDB:array=${target_var_chunk}"
 }
 echo ""
 


### PR DESCRIPTION
added parameters CHUNKSIZE_SP and CHUNKSIZE_T to the create options in order to adapt the chunksizes of the arrays in SciDB. Those parameter are optional and missing chunksize parameter will be calculated based on the total amount of hard drive space covered by one chunk (~32MB/chunk)
