### PR TITLE
Add default initial CreateType as S_ARRAY

### DIFF
--- a/src/shim_client_structs.h
+++ b/src/shim_client_structs.h
@@ -114,6 +114,7 @@ namespace scidb4gdal {
         * This function is intended to be called on constructing this structure and it initializes some attributes with default values
         */
         void _init() {
+            type = S_ARRAY;
             chunksize_spatial = -1;
             chunksize_temporal = -1;
             timestamp = "";


### PR DESCRIPTION
When I loading MODIS data into ScidB with scidb4gdal, it throws exceptions. Through debugging, I find out it is because that the member CreateType of CreationParameters is not initialized, so I add a default initial value for CreateType.